### PR TITLE
Make sure other blitzes can't use the same inputs as pummel.

### DIFF
--- a/randomizer.py
+++ b/randomizer.py
@@ -2953,7 +2953,7 @@ def manage_blitz():
         newlength = min(newlength, 10)
 
         newcmd = []
-        used_cmds = []
+        used_cmds = [[0xE, 0xA, 0xE]]
         while True:
             prev = newcmd[-1] if newcmd else None
             pprev = newcmd[-2] if len(newcmd) > 1 else None


### PR DESCRIPTION
Someone ran into this problem the other day. Aura Bolt had the same inputs as pummel, so they couldn't use Aura Bolt.